### PR TITLE
xwaylandvideobridge: drop

### DIFF
--- a/nixpkgs/flake.nix
+++ b/nixpkgs/flake.nix
@@ -155,7 +155,6 @@
           spectacle
           ffmpegthumbs
           krdp
-          xwaylandvideobridge
           ;
         qttools = lib.getBin pkgs.kdePackages.qttools;
 


### PR DESCRIPTION
Looks like `xwaylandvideobridge` has been removed from Nixpkgs. @darkyzhou 