### PR TITLE
flakes: add release-26.05

### DIFF
--- a/nixpkgs/release-26.05/flake.lock
+++ b/nixpkgs/release-26.05/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780092872,
+        "narHash": "sha256-EB+HMBsMcXJ9f3EpRBz7VlznlHjDjlnVlRoTWgc1C4U=",
+        "owner": "loongson-community",
+        "repo": "nixpkgs",
+        "rev": "56cc4af6d24bf0bea837ee05f92ff40036ad9028",
+        "type": "github"
+      },
+      "original": {
+        "owner": "loongson-community",
+        "ref": "loong-release-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nixpkgs/release-26.05/flake.nix
+++ b/nixpkgs/release-26.05/flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "Nix4Loong 26.05 nixpkgs builds";
+
+  inputs = {
+    nixpkgs.url = "github:loongson-community/nixpkgs?ref=loong-release-26.05";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      pkgs = import nixpkgs {
+        system = "loongarch64-linux";
+        config.allowUnfree = true;
+      };
+    in
+    {
+      hydraJobs = import ../pkgs.nix { inherit pkgs nixpkgs; };
+    };
+}


### PR DESCRIPTION
NixOS 26.05 will be released soon: https://github.com/NixOS/nixpkgs/pull/525947

Everything is building fine on https://hydra.nix4loong.cn/jobset/nixpkgs/release-26.05, but it would be nice to switch to the Nix4Loong repo rather than using mine.